### PR TITLE
rename a couple of fields to make integration with ES easier

### DIFF
--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -10,7 +10,9 @@
     <appender name="json" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <fieldNames>
-                <timestamp>timestamp</timestamp>
+                <timestamp>timegenerated</timestamp>
+                <level>level_name</level>
+                <message>msg</message>
             </fieldNames>
             <!--<prefix class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
                 <layout class="ch.qos.logback.classic.PatternLayout">

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -26,7 +26,9 @@
     <conversionRule conversionWord="syslogStart" converterClass="com.camptocamp.tomcatlogstash.Iso8601SyslogStartConverter"/>
     <appender name="logstash" class="net.logstash.logback.appender.LogstashSocketAppender">
         <fieldNames>
-            <timestamp>timestamp</timestamp>
+            <timestamp>timegenerated</timestamp>
+            <level>level_name</level>
+            <message>msg</message>
         </fieldNames>
         <prefix class="ch.qos.logback.classic.PatternLayout">
             <pattern>%syslogStart{USER}tomcat: @cee: </pattern>


### PR DESCRIPTION
 - "timegenerated" is our local standard to differentiate with the time
   when the log is processed. "timestamp" alone is ambiguous.
 - "level" yields a java.lang.NumberFormatException in ES. Need to
   investigate further.
 - "message" is also handled specially in the case of logstash, when
   processing JSON log messages.